### PR TITLE
Improve regex in identifySimpleSearch of DefaultDefinitionProvider

### DIFF
--- a/src/DefaultDefinitionProvider.ts
+++ b/src/DefaultDefinitionProvider.ts
@@ -580,7 +580,7 @@ export default abstract class DefaultDefinitionProvider extends BaseDefinitionPr
       lineText &&
       lineText.includes(this._definitionConfig.identifySimpleSearch) &&
       lineText.includes(referenceName) &&
-      new RegExp("\\s*var\\s+" + referenceName + "\\s+").test(lineText)
+      new RegExp("\\s*[var|const|let]\\s+" + referenceName + "\\s+").test(lineText)
     );
   }
 


### PR DESCRIPTION
Currently, if module required into variable that is not declared as var, e.g.:
`const ProductModel = require('~/cartridge/scripts/models/Product')`
it won't be suggestions of methods after "." trigger character. This change fixes that.